### PR TITLE
Fix: Rename misleading README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# The Linux Basics Course
+# Shell Scripts for Beginners Course
 
 These are notes from the [Shell Scripting for Beginners](https://kodekloud.com/courses/shell-scripts-for-beginners/) hosted on KodeKloud.
 
 # Sections
 
 - [01-Course-Introduction](docs/01-Course-Introduction)
+
   - [01-Course-Introduction](docs/01-Course-Introduction/01-Course-Introduction.md)
 
 - [02-Shell-Scripting-Introduction](docs/02-Shell-Scripting-Introduction)
+
   - [01-Project-Introduction](docs/02-Shell-Scripting-Introduction/01-Project-Introduction.md)
   - [02-Lab-Project-Introduction](docs/02-Shell-Scripting-Introduction/02-Lab-Project-Introduction.md)
   - [03-Creating-your-first-shell-script](docs/02-Shell-Scripting-Introduction/03-Creating-your-first-shell-script.md)
@@ -21,6 +23,7 @@ These are notes from the [Shell Scripting for Beginners](https://kodekloud.com/c
   - [12-Lab-Arithmetic-Operations](docs/02-Shell-Scripting-Introduction/12-Lab-Arithmetic-Operations.md)
 
 - [03-Flow-Control](docs/03-Flow-Control)
+
   - [01-Conditional-Logic](docs/03-Flow-Control/01-Conditional-Logic.md)
   - [02-Lab-Conditional-Logic](docs/03-Flow-Control/02-Lab-Conditional-Logic.md)
   - [03-Loops-For](docs/03-Flow-Control/03-Loops-For.md)
@@ -31,6 +34,7 @@ These are notes from the [Shell Scripting for Beginners](https://kodekloud.com/c
   - [08-Lab-Case-Statements](docs/03-Flow-Control/08-Lab-Case-Statements.md)
 
 - [04-Shebang](docs/04-Shebang)
+
   - [01-Shebang](docs/04-Shebang/01-Shebang.md)
   - [02-Lab-Shebang](docs/04-Shebang/02-Lab-Shebang.md)
   - [03-Exit-Codes](docs/04-Shebang/03-Exit-Codes.md)


### PR DESCRIPTION
Fix the misleading *README.md* title.

This is not **The Linux Basics Course**, it should be **Shell Scripts for Beginners Course**